### PR TITLE
Add parallelised version of `onesky_download`

### DIFF
--- a/lib/fastlane/plugin/onesky/actions/onesky_download_parallel_action.rb
+++ b/lib/fastlane/plugin/onesky/actions/onesky_download_parallel_action.rb
@@ -1,0 +1,88 @@
+module Fastlane
+  module Actions
+    class OneskyDownloadParallelAction < Action
+      def self.run(params)
+        Actions.verify_gem!('onesky-ruby')
+        require 'onesky'
+
+        client = ::Onesky::Client.new(params[:public_key], params[:secret_key])
+        project = client.project(params[:project_id])
+
+        threads = []
+        params[:locales].each do |locale|
+          destination = "#{params[:destination_dir]}/#{locale}.xliff"
+          UI.success "Downloading translation '#{locale}' of file '#{params[:filename]}' from OneSky to: '#{destination}'"
+          threads << Thread.new do
+            resp = project.export_translation(source_file_name: params[:filename], locale: locale)
+            File.open(destination, 'w') { |file| file.write(resp) }
+          end
+        end
+        threads.each { |t| t.join }
+      end
+
+      def self.description
+        'Download a translation file from OneSky in parallel'
+      end
+
+      def self.authors
+        ['danielkiedrowski']
+      end
+
+      def self.available_options
+        [
+          FastlaneCore::ConfigItem.new(key: :public_key,
+                                       env_name: 'ONESKY_PUBLIC_KEY',
+                                       description: 'Public key for OneSky',
+                                       is_string: true,
+                                       optional: false,
+                                       verify_block: proc do |value|
+                                         raise "No Public Key for OneSky given, pass using `public_key: 'token'`".red unless value and !value.empty?
+                                       end),
+          FastlaneCore::ConfigItem.new(key: :secret_key,
+                                       env_name: 'ONESKY_SECRET_KEY',
+                                       description: 'Secret Key for OneSky',
+                                       is_string: true,
+                                       optional: false,
+                                       verify_block: proc do |value|
+                                         raise "No Secret Key for OneSky given, pass using `secret_key: 'token'`".red unless value and !value.empty?
+                                       end),
+          FastlaneCore::ConfigItem.new(key: :project_id,
+                                       env_name: 'ONESKY_PROJECT_ID',
+                                       description: 'Project Id to upload file to',
+                                       optional: false,
+                                       verify_block: proc do |value|
+                                         raise "No project id given, pass using `project_id: 'id'`".red unless value and !value.empty?
+                                       end),
+          FastlaneCore::ConfigItem.new(key: :locales,
+                                       env_name: 'ONESKY_DOWNLOAD_LOCALE',
+                                       description: 'Locale to download the translation for',
+                                       is_string: false,
+                                       optional: false,
+                                       verify_block: proc do |value|
+                                         raise 'No locale for translation given'.red unless value and !value.empty?
+                                       end),
+          FastlaneCore::ConfigItem.new(key: :filename,
+                                       env_name: 'ONESKY_DOWNLOAD_FILENAME',
+                                       description: 'Name of the file to download the localization for',
+                                       is_string: true,
+                                       optional: false,
+                                       verify_block: proc do |value|
+                                         raise "No filename given. Please specify the filename of the file you want to download the translations for using `filename: 'filename'`".red unless value and !value.empty?
+                                       end),
+          FastlaneCore::ConfigItem.new(key: :destination_dir,
+                                       env_name: 'ONESKY_DOWNLOAD_DESTINATION_DIR',
+                                       description: 'Destination directory to put the downloaded files to',
+                                       is_string: true,
+                                       optional: false,
+                                       verify_block: proc do |value|
+                                         raise "Please specify the filename of the desrtination file you want to download the translations to using `destination: 'filename'`".red unless value and !value.empty?
+                                       end)
+        ]
+      end
+
+      def self.is_supported?(platform)
+        true
+      end
+    end
+  end
+end


### PR DESCRIPTION
I added a new action `onesky_download_parallel` which can download multiple locale files in parallel as downloading files by existing action takes a bit time. 

## Usage

`onesky_download_parallel` action has slightly different options. The differences are `locales` (plural) and `destination_dir`. We need to specify the list of locales which will be downloaded and the path of the directory to put downloaded files instead of specifying a file path one by one. 

```ruby
private_lane :download_translation_files do 
  onesky_download_parallel(
    project_id: "PROJECT_ID",
    locales: locales,
    filename: "FILENAME",
    destination_dir: "./tmp/"
  )
end
```

## Motivation

I have been working for a project which currently supports 17 languages in the mobile app. And we have a plan to expand support languages. The more we expand support, the more download time increases, of course. So it would be nice for us if `onesky_download` action finishes downloading many files quickly. 

For example, in our project, we manage 2 onesky projects to have different purpose of translations on each; one has 17 languages and the other one has 15 languages.  So downloading of those locale files takes more than 30 seconds like this😅 
 
```
| 12   | Switch to download_translations lane            | 0           |
| 13   | onesky_download                                 | 1           |
| 14   | onesky_download                                 | 1           |
| 15   | onesky_download                                 | 1           |
| 16   | onesky_download                                 | 1           |
| 17   | onesky_download                                 | 1           |
| 18   | onesky_download                                 | 1           |
| 19   | onesky_download                                 | 1           |
| 20   | onesky_download                                 | 1           |
| 21   | onesky_download                                 | 1           |
| 22   | onesky_download                                 | 1           |
| 23   | onesky_download                                 | 1           |
| 24   | onesky_download                                 | 1           |
| 25   | onesky_download                                 | 1           |
| 26   | onesky_download                                 | 1           |
| 27   | onesky_download                                 | 1           |
| 28   | onesky_download                                 | 1           |
| 29   | onesky_download                                 | 2           |
| 30   | onesky_download                                 | 1           |
| 31   | onesky_download                                 | 1           |
| 32   | onesky_download                                 | 2           |
| 33   | onesky_download                                 | 0           |
| 34   | onesky_download                                 | 1           |
| 35   | onesky_download                                 | 1           |
| 36   | onesky_download                                 | 0           |
| 37   | onesky_download                                 | 1           |
| 38   | onesky_download                                 | 1           |
| 39   | onesky_download                                 | 1           |
| 40   | onesky_download                                 | 1           |
| 41   | onesky_download                                 | 1           |
| 42   | onesky_download                                 | 1           |
| 43   | onesky_download                                 | 0           |
| 44   | onesky_download                                 | 0           |
| 45   | onesky_download                                 | 0           |
| 46   | onesky_download                                 | 1           |
```

In contrast to that, the parallelised action is done by around 4 secs.

```
| 13   | onesky_download_parallel                        | 2           |
| 14   | onesky_download_parallel                        | 2           |
```

## Implementation Details

As far as I know, each Fastlane's action isn't thread-safety so we need to encapslate multithreading inside the action. If we run this lane 

```ruby
private_lane :download_translation_files do 
  threads = []
  locales.each do |locale|
    threads << Thread.new do
      onesky_download(
        project_id: "PROJECT_ID",
        locale: locale,
        filename: "FILENAME",
        destination: "./tmp/#{locale}.xliff")
      )
    end
  end
  threads.each { |t| t.join }
end
```

we would see this error.

```
[01:00:10]: Error accessing file, this might be due to fastlane's directory handling
[01:00:10]: Check out https://docs.fastlane.tools/advanced/#directory-behavior for more details 
```

Therefore, we need to specify the list of locale and the path of the directory to put downloaded files instead.